### PR TITLE
[9주차 발제 STEP17 & STEP18] 카프카 활용 및 아웃박스 패턴 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
 	implementation 'mysql:mysql-connector-java:8.0.33'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation group: 'org.redisson', name: 'redisson-spring-boot-starter', version: '3.40.0'
+	implementation 'org.springframework.kafka:spring-kafka'
 }
 
 tasks.named('test') {

--- a/src/main/java/io/hhplus/concert/hhplusconcert/application/facade/PaymentFacade.java
+++ b/src/main/java/io/hhplus/concert/hhplusconcert/application/facade/PaymentFacade.java
@@ -19,6 +19,7 @@ public class PaymentFacade {
     private final PaymentService paymentService;
     private final PointService pointService;
     private final ConcertService concertService;
+    private final PaymentEventService paymentEventService;
 
     // 결제 진행
     @DistributedLock(key = "#lockName")
@@ -37,6 +38,9 @@ public class PaymentFacade {
         queueService.removeToken(token);
         // 결제 내역을 생성한다.
         Payment bill = paymentService.createBill(updatedReservation.id(), userId, seat.seatPrice());
+
+        // 이벤트를 발행한다.
+        paymentEventService.publishEvent(bill);
 
         return bill;
     }

--- a/src/main/java/io/hhplus/concert/hhplusconcert/application/scheduler/OutboxRetryScheduler.java
+++ b/src/main/java/io/hhplus/concert/hhplusconcert/application/scheduler/OutboxRetryScheduler.java
@@ -1,0 +1,40 @@
+package io.hhplus.concert.hhplusconcert.application.scheduler;
+
+import io.hhplus.concert.hhplusconcert.domain.component.port.MessageProducer;
+import io.hhplus.concert.hhplusconcert.domain.model.OutboxEvent;
+import io.hhplus.concert.hhplusconcert.domain.model.PaymentEvent;
+import io.hhplus.concert.hhplusconcert.domain.repository.OutboxRepository;
+import io.hhplus.concert.hhplusconcert.support.type.OutboxStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OutboxRetryScheduler {
+    private final OutboxRepository outboxRepository;
+    private final MessageProducer messageProducer;
+
+    @Scheduled(fixedDelay = 1000)
+    public void retryFailedOutboxEvents() {
+        List<OutboxEvent> failedEvents = outboxRepository.findByStatus(OutboxStatus.FAILED);
+        List<OutboxEvent> readyEvents = outboxRepository.findByStatus(OutboxStatus.READY_TO_PUBLISH);
+
+        failedEvents.forEach(event -> {
+            // 실패한 이벤트 재발행
+            messageProducer.send((PaymentEvent) event);
+        });
+
+        readyEvents.forEach(event -> {
+            // 1분이 지났는데 발행되지 않았으면 재발행
+            if (event.getCreatedAt().isAfter(LocalDateTime.now().minusMinutes(1))) {
+                messageProducer.send((PaymentEvent) event);
+            }
+        });
+    }
+}

--- a/src/main/java/io/hhplus/concert/hhplusconcert/domain/component/event/PaymentEventListener.java
+++ b/src/main/java/io/hhplus/concert/hhplusconcert/domain/component/event/PaymentEventListener.java
@@ -1,0 +1,27 @@
+package io.hhplus.concert.hhplusconcert.domain.component.event;
+
+import io.hhplus.concert.hhplusconcert.domain.component.port.MessageProducer;
+import io.hhplus.concert.hhplusconcert.domain.model.PaymentEvent;
+import io.hhplus.concert.hhplusconcert.domain.repository.OutboxRepository;
+import io.hhplus.concert.hhplusconcert.support.type.OutboxStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentEventListener {
+
+    private final OutboxRepository outboxRepository;
+    private final MessageProducer messageProducer;
+
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void readyHandle(PaymentEvent paymentEvent) {
+        log.info("readyHandle: {}", paymentEvent);
+        outboxRepository.save(paymentEvent);
+    }
+}

--- a/src/main/java/io/hhplus/concert/hhplusconcert/domain/component/port/MessageProducer.java
+++ b/src/main/java/io/hhplus/concert/hhplusconcert/domain/component/port/MessageProducer.java
@@ -1,0 +1,8 @@
+package io.hhplus.concert.hhplusconcert.domain.component.port;
+
+import io.hhplus.concert.hhplusconcert.domain.model.PaymentEvent;
+
+public interface MessageProducer {
+
+    void send(PaymentEvent paymentEvent);
+}

--- a/src/main/java/io/hhplus/concert/hhplusconcert/domain/model/OutboxEvent.java
+++ b/src/main/java/io/hhplus/concert/hhplusconcert/domain/model/OutboxEvent.java
@@ -1,0 +1,47 @@
+package io.hhplus.concert.hhplusconcert.domain.model;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.hhplus.concert.hhplusconcert.support.type.OutboxStatus;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class OutboxEvent {
+    private Long id;
+    private String topic;
+    private String aggregateType;
+    private Long aggregatedId;
+    private String eventType;
+    private String payload;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private OutboxStatus status;
+    private String uuid;
+
+    private static final ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+
+    // 객체를 JSON 문자열로 변환
+    public String toJson() {
+        try {
+            return objectMapper.writeValueAsString(this);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to convert to JSON", e);
+        }
+    }
+
+    // JSON 문자열을 객체로 변환
+    public static OutboxEvent fromJson(String json) {
+        try {
+            return objectMapper.readValue(json, OutboxEvent.class);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to parse JSON", e);
+        }
+    }
+}

--- a/src/main/java/io/hhplus/concert/hhplusconcert/domain/model/PaymentEvent.java
+++ b/src/main/java/io/hhplus/concert/hhplusconcert/domain/model/PaymentEvent.java
@@ -1,0 +1,40 @@
+package io.hhplus.concert.hhplusconcert.domain.model;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.hhplus.concert.hhplusconcert.support.type.OutboxStatus;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+public class PaymentEvent extends OutboxEvent {
+
+    public PaymentEvent(Long id, String topic, String aggregateType, Long aggregatedId, String eventType, String payload, LocalDateTime createdAt, LocalDateTime updatedAt, OutboxStatus status, String uuid) {
+        super(id, topic, aggregateType, aggregatedId, eventType, payload, createdAt, updatedAt, status, uuid);
+    }
+
+    public static PaymentEvent created(Payment payment, String topic) throws JsonProcessingException {
+        String aggregateType = "Payment";
+        Long aggregateId = payment.id();
+        String eventType = "Created";
+        String payload = payloadToString(payment);
+        LocalDateTime createdAt = payment.paymentAt();
+        LocalDateTime updatedAt = payment.paymentAt();
+        OutboxStatus status = OutboxStatus.READY_TO_PUBLISH;
+        String uuid = UUID.randomUUID().toString();
+
+        return new PaymentEvent(null, topic, aggregateType, aggregateId, eventType, payload, createdAt, updatedAt, status, uuid);
+    }
+
+    private static String payloadToString(Payment payment) throws JsonProcessingException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+
+        String payload = objectMapper.writeValueAsString(payment);
+
+        return payload;
+    }
+}

--- a/src/main/java/io/hhplus/concert/hhplusconcert/domain/repository/OutboxRepository.java
+++ b/src/main/java/io/hhplus/concert/hhplusconcert/domain/repository/OutboxRepository.java
@@ -1,0 +1,10 @@
+package io.hhplus.concert.hhplusconcert.domain.repository;
+
+import io.hhplus.concert.hhplusconcert.domain.model.OutboxEvent;
+import io.hhplus.concert.hhplusconcert.support.type.OutboxStatus;
+
+public interface OutboxRepository {
+    void save(OutboxEvent event);
+
+    void updateStatus(OutboxEvent event, OutboxStatus status);
+}

--- a/src/main/java/io/hhplus/concert/hhplusconcert/domain/repository/OutboxRepository.java
+++ b/src/main/java/io/hhplus/concert/hhplusconcert/domain/repository/OutboxRepository.java
@@ -3,8 +3,12 @@ package io.hhplus.concert.hhplusconcert.domain.repository;
 import io.hhplus.concert.hhplusconcert.domain.model.OutboxEvent;
 import io.hhplus.concert.hhplusconcert.support.type.OutboxStatus;
 
+import java.util.List;
+
 public interface OutboxRepository {
     void save(OutboxEvent event);
 
     void updateStatus(OutboxEvent event, OutboxStatus status);
+
+    List<OutboxEvent> findByStatus(OutboxStatus status);
 }

--- a/src/main/java/io/hhplus/concert/hhplusconcert/domain/service/PaymentEventService.java
+++ b/src/main/java/io/hhplus/concert/hhplusconcert/domain/service/PaymentEventService.java
@@ -1,0 +1,31 @@
+package io.hhplus.concert.hhplusconcert.domain.service;
+
+import io.hhplus.concert.hhplusconcert.domain.model.Payment;
+import io.hhplus.concert.hhplusconcert.domain.model.PaymentEvent;
+import io.hhplus.concert.hhplusconcert.support.code.ErrorType;
+import io.hhplus.concert.hhplusconcert.support.exception.CoreException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PaymentEventService {
+
+    @Value("${event.payment.topic}")
+    private String topic;
+
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    public void publishEvent(Payment payment) {
+        try {
+            applicationEventPublisher.publishEvent(PaymentEvent.created(payment, topic));
+        } catch (Exception e) {
+            log.error("Failed to publish payment event: ", e);
+            throw new CoreException(ErrorType.INTERNAL_ERROR, "Failed to publish payment event");
+        }
+    }
+}

--- a/src/main/java/io/hhplus/concert/hhplusconcert/infra/entity/OutboxEntity.java
+++ b/src/main/java/io/hhplus/concert/hhplusconcert/infra/entity/OutboxEntity.java
@@ -75,6 +75,7 @@ public class OutboxEntity {
                 .createdAt(this.createdAt)
                 .updatedAt(this.updatedAt)
                 .status(this.status)
+                .uuid(this.uuid)
                 .build();
     }
 

--- a/src/main/java/io/hhplus/concert/hhplusconcert/infra/entity/OutboxEntity.java
+++ b/src/main/java/io/hhplus/concert/hhplusconcert/infra/entity/OutboxEntity.java
@@ -1,0 +1,85 @@
+package io.hhplus.concert.hhplusconcert.infra.entity;
+
+import io.hhplus.concert.hhplusconcert.domain.model.OutboxEvent;
+import io.hhplus.concert.hhplusconcert.support.type.OutboxStatus;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@Entity(name = "outbox")
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class OutboxEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String topic;
+
+    @Column(nullable = false)
+    private String aggregateType;
+
+    @Column(nullable = false)
+    private Long aggregatedId;
+
+    @Column(nullable = false)
+    private String eventType;
+
+    @Lob
+    @Column(nullable = false)
+    private String payload;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Column(nullable = false)
+    @Enumerated(value = EnumType.STRING)
+    private OutboxStatus status;
+
+    @Column(nullable = false)
+    private String uuid;
+
+    public static OutboxEntity from(OutboxEvent event) {
+        return OutboxEntity.builder()
+                .topic(event.getTopic())
+                .aggregateType(event.getAggregateType())
+                .aggregatedId(event.getAggregatedId())
+                .eventType(event.getEventType())
+                .payload(event.getPayload())
+                .createdAt(event.getCreatedAt())
+                .updatedAt(event.getUpdatedAt())
+                .status(event.getStatus())
+                .uuid(event.getUuid())
+                .build();
+    }
+
+    public OutboxEvent of() {
+        return OutboxEvent.builder()
+                .id(this.id)
+                .topic(this.topic)
+                .aggregateType(this.aggregateType)
+                .aggregatedId(this.aggregatedId)
+                .eventType(this.eventType)
+                .payload(this.payload)
+                .createdAt(this.createdAt)
+                .updatedAt(this.updatedAt)
+                .status(this.status)
+                .build();
+    }
+
+    public void changeStatus(OutboxStatus status) {
+        this.updatedAt = LocalDateTime.now();
+        this.status = status;
+    }
+}

--- a/src/main/java/io/hhplus/concert/hhplusconcert/infra/kafka/producer/KafkaMessageProducer.java
+++ b/src/main/java/io/hhplus/concert/hhplusconcert/infra/kafka/producer/KafkaMessageProducer.java
@@ -1,0 +1,30 @@
+package io.hhplus.concert.hhplusconcert.infra.kafka.producer;
+
+import io.hhplus.concert.hhplusconcert.domain.component.port.MessageProducer;
+import io.hhplus.concert.hhplusconcert.domain.model.PaymentEvent;
+import io.hhplus.concert.hhplusconcert.support.code.ErrorType;
+import io.hhplus.concert.hhplusconcert.support.exception.CoreException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KafkaMessageProducer implements MessageProducer {
+
+    private final KafkaTemplate<String, String> kafkaTemplate;
+
+    @Override
+    public void send(PaymentEvent paymentEvent) {
+        try {
+            ProducerRecord<String, String> producerRecord = new ProducerRecord<>(paymentEvent.getTopic(), paymentEvent.toJson());
+            kafkaTemplate.send(producerRecord);
+        } catch (Exception e) {
+            log.error("Error publishing event to Kafka: {}", e);
+            throw new CoreException(ErrorType.INTERNAL_ERROR, "Error publishing event to Kafka");
+        }
+    }
+}

--- a/src/main/java/io/hhplus/concert/hhplusconcert/infra/repository/impl/OutboxRepositoryImpl.java
+++ b/src/main/java/io/hhplus/concert/hhplusconcert/infra/repository/impl/OutboxRepositoryImpl.java
@@ -10,6 +10,8 @@ import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Repository
 @RequiredArgsConstructor
 public class OutboxRepositoryImpl implements OutboxRepository {
@@ -26,5 +28,12 @@ public class OutboxRepositoryImpl implements OutboxRepository {
     public void updateStatus(OutboxEvent event, OutboxStatus status) {
         OutboxEntity outboxEntity = outboxJpaRepository.findByUuid(event.getUuid());
         outboxEntity.changeStatus(status);
+    }
+
+    @Override
+    public List<OutboxEvent> findByStatus(OutboxStatus status) {
+        return outboxJpaRepository.findByStatus(status).stream()
+                .map(OutboxEntity::of)
+                .toList();
     }
 }

--- a/src/main/java/io/hhplus/concert/hhplusconcert/infra/repository/impl/OutboxRepositoryImpl.java
+++ b/src/main/java/io/hhplus/concert/hhplusconcert/infra/repository/impl/OutboxRepositoryImpl.java
@@ -1,0 +1,30 @@
+package io.hhplus.concert.hhplusconcert.infra.repository.impl;
+
+import io.hhplus.concert.hhplusconcert.domain.model.OutboxEvent;
+import io.hhplus.concert.hhplusconcert.domain.repository.OutboxRepository;
+import io.hhplus.concert.hhplusconcert.infra.entity.OutboxEntity;
+import io.hhplus.concert.hhplusconcert.infra.repository.jpa.OutboxJpaRepository;
+import io.hhplus.concert.hhplusconcert.support.type.OutboxStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+@RequiredArgsConstructor
+public class OutboxRepositoryImpl implements OutboxRepository {
+
+    private final OutboxJpaRepository outboxJpaRepository;
+
+    @Override
+    public void save(OutboxEvent event) {
+        outboxJpaRepository.save(OutboxEntity.from(event));
+    }
+
+    @Override
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void updateStatus(OutboxEvent event, OutboxStatus status) {
+        OutboxEntity outboxEntity = outboxJpaRepository.findByUuid(event.getUuid());
+        outboxEntity.changeStatus(status);
+    }
+}

--- a/src/main/java/io/hhplus/concert/hhplusconcert/infra/repository/jpa/OutboxJpaRepository.java
+++ b/src/main/java/io/hhplus/concert/hhplusconcert/infra/repository/jpa/OutboxJpaRepository.java
@@ -1,0 +1,8 @@
+package io.hhplus.concert.hhplusconcert.infra.repository.jpa;
+
+import io.hhplus.concert.hhplusconcert.infra.entity.OutboxEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OutboxJpaRepository extends JpaRepository<OutboxEntity, Long> {
+    OutboxEntity findByUuid(String uuid);
+}

--- a/src/main/java/io/hhplus/concert/hhplusconcert/infra/repository/jpa/OutboxJpaRepository.java
+++ b/src/main/java/io/hhplus/concert/hhplusconcert/infra/repository/jpa/OutboxJpaRepository.java
@@ -1,8 +1,12 @@
 package io.hhplus.concert.hhplusconcert.infra.repository.jpa;
 
 import io.hhplus.concert.hhplusconcert.infra.entity.OutboxEntity;
+import io.hhplus.concert.hhplusconcert.support.type.OutboxStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
 
 public interface OutboxJpaRepository extends JpaRepository<OutboxEntity, Long> {
     OutboxEntity findByUuid(String uuid);
+    List<OutboxEntity> findByStatus(OutboxStatus status);
 }

--- a/src/main/java/io/hhplus/concert/hhplusconcert/interfaces/kafka/consumer/ConcertPaymentMessageConsumer.java
+++ b/src/main/java/io/hhplus/concert/hhplusconcert/interfaces/kafka/consumer/ConcertPaymentMessageConsumer.java
@@ -1,0 +1,40 @@
+package io.hhplus.concert.hhplusconcert.interfaces.kafka.consumer;
+
+import io.hhplus.concert.hhplusconcert.domain.model.OutboxEvent;
+import io.hhplus.concert.hhplusconcert.domain.model.PaymentEvent;
+import io.hhplus.concert.hhplusconcert.domain.repository.OutboxRepository;
+import io.hhplus.concert.hhplusconcert.support.type.OutboxStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.messaging.Message;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class ConcertPaymentMessageConsumer implements KafkaMessageConsumer {
+
+    private final OutboxRepository outboxRepository;
+
+    @Override
+    @KafkaListener(topics = "concert-payment", groupId = "concert")
+    public void handle(Message<String> message, Acknowledgment acknowledgment) {
+        log.info("Received headers: {}, payload: {}", message.getHeaders(), message.getPayload());
+
+        try {
+            // 1. 로직 처리
+            OutboxEvent outboxEvent = PaymentEvent.fromJson(message.getPayload());
+            // 여기에 추가
+
+            // 2. outbox 테이블에 이벤트 처리 상태를 업데이트
+            outboxRepository.updateStatus(outboxEvent, OutboxStatus.MESSAGE_CONSUME);
+
+            // 3. ack 처리
+            acknowledgment.acknowledge();
+        } catch (Exception e) {
+            log.error("Error processing Kafka message", e);
+        }
+    }
+}

--- a/src/main/java/io/hhplus/concert/hhplusconcert/interfaces/kafka/consumer/KafkaMessageConsumer.java
+++ b/src/main/java/io/hhplus/concert/hhplusconcert/interfaces/kafka/consumer/KafkaMessageConsumer.java
@@ -1,0 +1,8 @@
+package io.hhplus.concert.hhplusconcert.interfaces.kafka.consumer;
+
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.messaging.Message;
+
+public interface KafkaMessageConsumer {
+    void handle(Message<String> message, Acknowledgment acknowledgment);
+}

--- a/src/main/java/io/hhplus/concert/hhplusconcert/support/type/OutboxStatus.java
+++ b/src/main/java/io/hhplus/concert/hhplusconcert/support/type/OutboxStatus.java
@@ -1,0 +1,8 @@
+package io.hhplus.concert.hhplusconcert.support.type;
+
+public enum OutboxStatus {
+    READY_TO_PUBLISH,
+    PUBLISHED,
+    MESSAGE_CONSUME,
+    FAILED
+}

--- a/src/test/java/io/hhplus/concert/hhplusconcert/httpclient/ReservationControllerTest.http
+++ b/src/test/java/io/hhplus/concert/hhplusconcert/httpclient/ReservationControllerTest.http
@@ -1,0 +1,22 @@
+### 콘서트 좌석 예약
+
+POST localhost:8080/api/v1/reservations
+Content-Type: application/json
+Token: 49968117-7c77-390c-99a0-3fc68f4b127e
+
+{
+  "userId": 1,
+  "concertId": 1,
+  "scheduleId": 1,
+  "seatId": 1
+}
+
+### 콘서트 결제
+POST localhost:8080/api/v1/payments
+Content-Type: application/json
+Token: 49968117-7c77-390c-99a0-3fc68f4b127e
+
+{
+  "userId": 1,
+  "reservationId": 1
+}


### PR DESCRIPTION
# **커밋 링크**

## 주요 로직
- [결제로직에 이벤트 발행 로직](https://github.com/hubls/hhplus-concert/commit/2e50a2b1ba6801097f48d9a4e1a37582b6f5136e)
- [이벤트 발행 전 Outbox 테이블 레코드 추가(READY_TO_PUBLISH 상태)](https://github.com/hubls/hhplus-concert/commit/065b4c53e883d5e268f4a07dcd972f639b0cbc70)
- [이벤트 발행 후 카프카 메시지 발행 및 Outbox 레코드 상태 변경(READY_TO_PUBLISH -> PUBLISHED)](https://github.com/hubls/hhplus-concert/commit/e4f7cfbd25950f5440017aee8be24a44aafced79)
- [발행된 카프라 메시지 컨슈머 그룹이 소비하는 로직 및 Outbox 레코드 상태 변경 (PUBLISHED -> MESSAGE_CONSUME)](https://github.com/hubls/hhplus-concert/commit/e7a9b5cfdba766740e52dce3a46beb6636b421db)
- [Feat: FAILED 메시지 혹은 READY후 발행되지 않은 메시지 다시 발행하는 스케줄러 기능](https://github.com/hubls/hhplus-concert/commit/091938e9481d634f6ad3f08a4a3868af0074330c)

---

## 리뷰 포인트
이번 주차는 다른 주차 보다 많이 부족했던 주차였습니다... kafka를 설정하고 연결해보느라고 시간을 많이 쏟다보니 실제 로직 구현에 힘이 덜 실렸던 것 같습니다😭😭

[[MSA] Transactional Outbox Pattern](https://curiousjinan.tistory.com/entry/transactional-outbox-pattern-microservices-kafka#%EB%B0%9C%ED%96%89%EB%90%9C%20kafka%20%EB%A9%94%EC%8B%9C%EC%A7%80%EB%8A%94%20%EA%B0%81%20%EC%84%9C%EB%B2%84%EC%97%90%EC%84%9C%20%EC%96%B4%EB%96%BB%EA%B2%8C%20consume%ED%95%B4%EC%84%9C%20%EC%82%AC%EC%9A%A9%ED%95%A0%EA%B9%8C%3F-1) 이 글에서 대부분 참고하였으며, 도커 설정도 유사하게 설정해서 진행했습니다!


1. 전반적으로 Outbox 패턴을 구현함에 있어서 아래와 같이 이해했고 아래와 같이 구현했습니다. 이해를 돕기 위해 시간을 조금 비약적으로 설정하면서 단계적으로 제가 이해한 내용이 맞는지 검증을 부탁드립니다...!
   1. 결제 시스템 트랜잭션 시작(11시 1분)
   2. 결제 시스템 트랜잭션 커밋 전 Outbox 레코드(READY_TO_PUBLISH) 추가(11시 2분)
   3. 결제 시스템 트랜잭션 커밋(11시 3분)
   4. 결제 시스템 커밋 후 카프카 발행 및 Outbox 레코드 상태 변경(PUBLISHED) (11시 4분)
      1. 만약 여기서 발행하는데 오류가 발생하면 Outbox 레코드 상태 변경(FAILED)
   5. 카프카에 발행된 메시지를 확인 후 컨슈머가 비즈니스 로직 처리 및 Outbox 상태 변경(MESSAGE_CONSUME) (11시 5분)

### 강점
- Outbox 레코드에 기록이 되니까 이 기록을 바탕으로 만약 카프카에서 처리를 제대로 못했더라도 Outbox 레코드 기록을 기반으로 다시 처리해줄 수 있음.
- 현재는 결제 시스템과 엮여져 있어서 그렇지만, 만약 MSA환경이었다면, 이벤트 기반으로 결제는 결제대로, 포인트는 포인트대로, 예약은 예약대로 책임 분리가 명확해짐.(이 부분은 Outbox 패턴의 강점 보다는 Kafka를 사용함에 있어서 강점이 조금 더 맞는것 같기는 합니다.)

이번 주차를 진행하면서 전반적으로 이해한 내용은 위와 같습니다. 

2. 다른 것보다 Consume을 Outbox 레코드에서 처리해주면서 느낀 것인데 이렇게 status를 Consume처리를 해주게 되면 다른 로직에서 처리했는지 안한건지 구분을 어떻게 할 수 있지...? 라는 생각이 들었습니다.
   예를들면, 결제에서 "나 결제 메시지 발행했어!" 했을때 Consumer가 예약서비스, 포인트서비스 이렇게 2개라면 Outbox 레코드에서 예약 서비스가 status를 Consume으로 바꾼것인지, 아니면 포인트 서비스가 Consume으로 status로 바꾼것인지 구분이 가능한가? 라는 생각을 한 것 같습니다. 저는 그래도 일단 로직 처리를 했다고 가정하고 Status를 Consume으로 처리하기는 했는데 이러한 방식을 어떻게 생각하시는지 궁금합니다!

3. 
`OutboxRepositoryImpl.java`
```java
@Override
@Transactional(propagation = Propagation.REQUIRES_NEW)
public void updateStatus(OutboxEvent event, OutboxStatus status) {
    OutboxEntity outboxEntity = outboxJpaRepository.findByUuid(event.getUuid());
    outboxEntity.changeStatus(status);
}
```
이 부분을 이렇게 새로운 트랜잭션을 열어서 수행해줬는데 이렇게 안하면 안되더라구요ㅠㅠ 찾아본결과 상위 메서드에서 `@async`를 사용해서 생긴 문제로 파악됩니다.
[스택오버 플로우 같은 고민 한사람](https://stackoverflow.com/questions/55355200/spring-boot-with-async-method-with-jpa-entity-update) 이 사람도 저와 비슷한 고민을 한것으로 보이는데, 제가 해결한 방식이 적절 했는지 궁금합니다!
적절하지 않았다면, 만약 `@async`사용한 상황에서 update를 해야한다면 적절한 조치가 궁금합니다!


바쁘실텐데 시간내서 리뷰해주셔서 감사합니다😊😊